### PR TITLE
extlinux.conf: Add menu items for displays with SMARC Eval Carrier 2.2

### DIFF
--- a/board/kontron/smarc-sam67/extlinux.conf
+++ b/board/kontron/smarc-sam67/extlinux.conf
@@ -16,6 +16,20 @@ label module-ads2
   devicetree-overlay /k3-am67a-kontron-sa67-ads2.dtbo
   append root=PARTUUID=%PARTUUID% rootwait
 
+label module-ads2-rev-2-lvds-evervision-vgg644804
+  menu label Eval Carrier 2.2 with LVDS evervision-vgg644804 [module-ads2-rev-2-lvds-evervision-vgg644804]
+  kernel /Image
+  devicetree /k3-am67a-kontron-sa67.dtb
+  devicetree-overlay /k3-am67a-kontron-sa67-ads2.dtbo /k3-am67a-kontron-sa67-lvds0-evervision-vgg644804.dtbo
+  append root=PARTUUID=%PARTUUID% rootwait
+
+label module-ads2-rev-2-lvds-auo-p238han01
+  menu label Eval Carrier 2.2 with LVDS AUO-P238HAN01 [module-ads2-rev-2-lvds-auo-p238han01]
+  kernel /Image
+  devicetree /k3-am67a-kontron-sa67.dtb
+  devicetree-overlay /k3-am67a-kontron-sa67-ads2.dtbo /k3-am67a-kontron-sa67-lvds-auo-p238han01.dtbo
+  append root=PARTUUID=%PARTUUID% rootwait
+
 label module-ads2-rev-1-lvds-evervision-vgg644804
   menu label Eval Carrier 2.1 with LVDS evervision-vgg644804 [module-ads2-rev-1-lvds-evervision-vgg644804]
   kernel /Image


### PR DESCRIPTION
`k3-am67a-kontron-ads2-rev-a-fixups.dtbo` is only needed on the Eval Carrier 2.1. Applying it on later versions breaks the display.